### PR TITLE
Fixing shutting down problem.

### DIFF
--- a/src/qt_executor.cpp
+++ b/src/qt_executor.cpp
@@ -29,7 +29,10 @@ QtExecutor::start()
        while(rclcpp::ok(this->context_))
        {
            wait_for_work();
-           onNewWork();
+           if(rclcpp::ok(this->context_)) {
+               // If we are shutting down, we must not call onNewWork because the QT Event loop is closed.
+               onNewWork();
+           }
        }
        QMetaObject::invokeMethod(QCoreApplication::instance(), "quit", Qt::ConnectionType::QueuedConnection);
     });


### PR DESCRIPTION
This PR solve the issue #1 .

The problem was that we was calling onNewNetwork, after the QT event loop was deleted. And this function is a QT Slot, so we hang in it until a QProcessEvent was called.