### PR TITLE
Choosing the right Executor and ExecutorOptions class accordingly to the RCLCPP Version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
+if(rclcpp_VERSION_MAJOR GREATER_EQUAL 2)
+    message("Foxy or newer rclcpp detected")
+    add_compile_definitions(POST_FOXY)
+endif(rclcpp_VERSION_MAJOR GREATER_EQUAL 2)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 find_package(Qt5 COMPONENTS Core REQUIRED)

--- a/include/libros2qt/qt_executor.h
+++ b/include/libros2qt/qt_executor.h
@@ -22,9 +22,17 @@
 #include "rclcpp/rate.hpp"
 #include "rclcpp/visibility_control.hpp"
 
+#ifdef POST_FOXY
+  using Executor = rclcpp::Executor;
+  using ExecutorOptions = rclcpp::ExecutorOptions;
+#else
+    using Executor = rclcpp::executor::Executor;
+    using ExecutorOptions = rclcpp::executor::ExecutorArgs;
+#endif
+
 /// Single-threaded executor implementation
 // This is the default executor created by rclcpp::spin.
-class QtExecutor : public QObject, public rclcpp::executor::Executor
+class QtExecutor : public QObject, public Executor
 {
     Q_OBJECT
 public:
@@ -32,8 +40,7 @@ public:
 
   /// Default constructor. See the default constructor for Executor.
   RCLCPP_PUBLIC
-  QtExecutor(
-    const rclcpp::executor::ExecutorArgs & args = rclcpp::executor::ExecutorArgs());
+  QtExecutor(const ExecutorOptions &args = ExecutorOptions());
 
   /// Default destrcutor.
   RCLCPP_PUBLIC

--- a/src/qt_executor.cpp
+++ b/src/qt_executor.cpp
@@ -8,7 +8,7 @@
 
 using namespace rclcpp;
 
-QtExecutor::QtExecutor(const rclcpp::executor::ExecutorArgs & args)
+QtExecutor::QtExecutor(const ExecutorOptions &args)
 : executor::Executor(args) {
     connect(this, &QtExecutor::onNewWork, this, &QtExecutor::processWork, Qt::ConnectionType::BlockingQueuedConnection);
 }


### PR DESCRIPTION
For post foxy version, rclcpp::executor::Executor and rclcpp::executor::ExecutorArgs are deprecated.