### PR TITLE
cmake: remove use of ament_target_dependencies() on POST FOXY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,11 @@ target_include_directories(libros2qt PUBLIC
 if(rclcpp_VERSION_MAJOR GREATER_EQUAL 2)
   message("Foxy or newer rclcpp detected")
   target_compile_definitions(libros2qt PUBLIC POST_FOXY)
+  target_link_libraries(libros2qt rclcpp::rclcpp Qt${QT_VERSION_MAJOR}::Core)
+else()
+  target_link_libraries(libros2qt Qt${QT_VERSION_MAJOR}::Core)
+  ament_target_dependencies(libros2qt rclcpp)
 endif()
-target_link_libraries(libros2qt Qt${QT_VERSION_MAJOR}::Core)
-ament_target_dependencies(libros2qt rclcpp)
 
 if(COMPILE_EXAMPLES)
   add_executable(testnode examples/timers/main.cpp examples/timers/node.cpp)


### PR DESCRIPTION
To avoid build warnings on Kilted:

```
Starting >>> libros2qt
--- stderr: libros2qt
Foxy or newer rclcpp detected
CMake Deprecation Warning at /opt/ros/kilted/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:87 (message):
  ament_target_dependencies() is deprecated.  Use target_link_libraries()
  with modern CMake targets instead.  Try replacing this call with:

    target_link_libraries(libros2qt PUBLIC
      rclcpp::rclcpp
    )

Call Stack (most recent call first):
  CMakeLists.txt:41 (ament_target_dependencies)


---
Finished <<< libros2qt [2.78s]
```

Should be backward compatible on previous releases of ROS 2.